### PR TITLE
Clarify error messages when reading files

### DIFF
--- a/src/bin/rsign/main.rs
+++ b/src/bin/rsign/main.rs
@@ -120,8 +120,26 @@ where
     P: AsRef<Path>,
     Q: AsRef<Path>,
 {
-    let signature_box = SignatureBox::from_file(signature_path)?;
-    let (data_reader, _should_be_prehashed) = open_data_file(data_path)?;
+    let signature_box = SignatureBox::from_file(&signature_path).map_err(|err| {
+        PError::new(
+            ErrorKind::Io,
+            format!(
+                "could not read signature file {}: {}",
+                signature_path.as_ref().display(),
+                err
+            ),
+        )
+    })?;
+    let (data_reader, _should_be_prehashed) = open_data_file(&data_path).map_err(|err| {
+        PError::new(
+            ErrorKind::Io,
+            format!(
+                "could not read data file {}: {}",
+                data_path.as_ref().display(),
+                err
+            ),
+        )
+    })?;
     verify(&pk, &signature_box, data_reader, quiet, output)
 }
 


### PR DESCRIPTION
Previously, trying to operate on a non-existing data or signature file
only printed a generic IO error, without mentioning the operation nor
the actual expected file. This was particularly unintuitive as I did not
know whether the tool expected to be pointed to the file or to the
signature in the first place, and it took a few attempts to figure it
out (or perhaps I should have just read the documentation...).