### PR TITLE
update to clap 4.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "rsign2"
 version = "0.6.1"
+edition = "2021"
 authors = [
     "Frank Denis <github@pureftpd.org>",
     "Daniel Rangel <daniel@rangel.in>",
@@ -13,7 +14,7 @@ keywords = ["command-line", "sign", "publickey", "cryptography", "minisign"]
 repository = "https://github.com/jedisct1/rsign2"
 
 [dependencies]
-clap = { version = "3", features = ["std", "cargo", "wrap_help"] }
+clap = { version = "4.1.1", features = ["std", "cargo", "wrap_help"] }
 minisign = "0.7"
 
 [target.'cfg(any(windows, unix))'.dependencies]

--- a/src/bin/rsign/main.rs
+++ b/src/bin/rsign/main.rs
@@ -1,9 +1,3 @@
-#[macro_use]
-extern crate clap;
-#[cfg(any(windows, unix))]
-extern crate dirs;
-extern crate minisign;
-
 mod helpers;
 mod parse_args;
 
@@ -50,8 +44,8 @@ force this operation.",
             std::fs::remove_file(pk_path)?;
         }
     }
-    let mut pk_writer = create_file(pk_path, 0o644)?;
-    let mut sk_writer = create_file(sk_path, 0o600)?;
+    let mut pk_writer = create_file(pk_path, 0o644, force)?;
+    let mut sk_writer = create_file(sk_path, 0o600, force)?;
     let kp = KeyPair::generate_and_write_encrypted_keypair(
         &mut pk_writer,
         &mut sk_writer,
@@ -151,77 +145,13 @@ where
     )
 }
 
-fn create_sk_path_or_default(sk_path_str: Option<&str>, force: bool) -> Result<PathBuf> {
-    let sk_path = match sk_path_str {
-        Some(path) => {
-            let complete_path = PathBuf::from(path);
-            let mut dir = complete_path.clone();
-            dir.pop();
-            create_dir(&dir)?;
-            complete_path
-        }
-        None => match std::env::var(SIG_DEFAULT_CONFIG_DIR_ENV_VAR) {
-            Ok(env_path) => {
-                let mut complete_path = PathBuf::from(env_path);
-                if !complete_path.exists() {
-                    return Err(PError::new(
-                        ErrorKind::Io,
-                        format!(
-                            "folder {} referenced by {} doesn't exists, you'll have to create \
-                             yourself",
-                            complete_path.display(),
-                            SIG_DEFAULT_CONFIG_DIR_ENV_VAR
-                        ),
-                    ));
-                }
-                complete_path.push(SIG_DEFAULT_SKFILE);
-                complete_path
-            }
-            Err(_) => {
-                let home_path =
-                    home_dir().ok_or_else(|| PError::new(ErrorKind::Io, "can't find home dir"))?;
-                let mut complete_path = home_path;
-                complete_path.push(SIG_DEFAULT_CONFIG_DIR);
-                if !complete_path.exists() {
-                    create_dir(&complete_path)?;
-                }
-                complete_path.push(SIG_DEFAULT_SKFILE);
-                complete_path
-            }
-        },
-    };
-    if sk_path.exists() {
-        if !force {
-            return Err(PError::new(
-                ErrorKind::Io,
-                format!(
-                    "Key generation aborted:
-{} already exists
-
-If you really want to overwrite the existing key pair, add the -f switch to
-force this operation.",
-                    sk_path.display()
-                ),
-            ));
-        } else {
-            std::fs::remove_file(&sk_path)?;
-        }
-    }
-    Ok(sk_path)
-}
-
-fn get_pk_path(explicit_path: Option<&str>) -> Result<PathBuf> {
-    Ok(PathBuf::from(explicit_path.unwrap_or(SIG_DEFAULT_PKFILE)))
-}
-
-fn get_sk_path(explicit_path: Option<&str>) -> Result<PathBuf> {
-    let default_file_name = SIG_DEFAULT_SKFILE;
+fn get_pk_path(explicit_path: Option<&PathBuf>) -> Result<PathBuf> {
     match explicit_path {
-        Some(explicit_path) => Ok(PathBuf::from(explicit_path)),
+        Some(explicit_path) => Ok(explicit_path.clone()),
         None => match std::env::var(SIG_DEFAULT_CONFIG_DIR_ENV_VAR) {
             Ok(env_path) => {
                 let mut complete_path = PathBuf::from(env_path);
-                complete_path.push(default_file_name);
+                complete_path.push(SIG_DEFAULT_PKFILE);
                 Ok(complete_path)
             }
             Err(_) => {
@@ -229,77 +159,120 @@ fn get_sk_path(explicit_path: Option<&str>) -> Result<PathBuf> {
                     home_dir().ok_or_else(|| PError::new(ErrorKind::Io, "can't find home dir"))?;
                 let mut complete_path = home_path;
                 complete_path.push(SIG_DEFAULT_CONFIG_DIR);
-                complete_path.push(default_file_name);
+                complete_path.push(SIG_DEFAULT_PKFILE);
                 Ok(complete_path)
             }
         },
     }
 }
 
-fn run(args: clap::ArgMatches, help_usage: &str) -> Result<()> {
-    if let Some(generate_action) = args.subcommand_matches("generate") {
-        let force = generate_action.is_present("force");
-        let pk_path = get_pk_path(generate_action.value_of("pk_path"))?;
-        let sk_path_str = generate_action.value_of("sk_path");
-        let sk_path = create_sk_path_or_default(sk_path_str, force)?;
-        let comment = generate_action.value_of("comment");
-        let KeyPair { pk, .. } = cmd_generate(force, &pk_path, &sk_path, comment)?;
-        println!(
-            "\nThe secret key was saved as {} - Keep it secret!",
-            sk_path.display()
-        );
-        println!(
-            "The public key was saved as {} - That one can be public.\n",
-            pk_path.display()
-        );
-        println!("Files signed using this key pair can be verified with the following command:\n");
-        println!("rsign verify <file> -P {}", pk.to_base64());
-        Ok(())
-    } else if let Some(sign_action) = args.subcommand_matches("sign") {
-        let sk_path = get_sk_path(sign_action.value_of("sk_path"))?;
-        let pk = if let Some(pk_inline) = sign_action.value_of("public_key") {
-            Some(PublicKey::from_base64(pk_inline)?)
-        } else if let Some(pk_path) = sign_action.value_of("pk_path") {
-            Some(PublicKey::from_file(get_pk_path(Some(pk_path))?)?)
-        } else {
-            None
-        };
-        let data_path = PathBuf::from(sign_action.value_of("data").unwrap()); // safe to unwrap
-        let signature_path = if let Some(file) = sign_action.value_of("sig_file") {
-            PathBuf::from(file)
-        } else {
-            PathBuf::from(format!("{}{}", data_path.display(), SIG_SUFFIX))
-        };
-        let trusted_comment = sign_action.value_of("trusted-comment");
-        let untrusted_comment = sign_action.value_of("untrusted-comment");
-        cmd_sign(
-            pk,
-            sk_path,
-            signature_path,
-            &data_path,
-            trusted_comment,
-            untrusted_comment,
-        )
-    } else if let Some(verify_action) = args.subcommand_matches("verify") {
-        let pk = if let Some(pk_inline) = verify_action.value_of("public_key") {
-            PublicKey::from_base64(pk_inline)?
-        } else {
-            PublicKey::from_file(get_pk_path(verify_action.value_of("pk_path"))?)?
-        };
-        let data_path = verify_action.value_of("file").unwrap();
-        let signature_path = if let Some(path) = verify_action.value_of("sig_file") {
-            PathBuf::from(path)
-        } else {
-            PathBuf::from(format!("{data_path}{SIG_SUFFIX}"))
-        };
-        let quiet = verify_action.is_present("quiet");
-        let output = verify_action.is_present("output");
-        let allow_legacy = verify_action.is_present("allow-legacy");
-        cmd_verify(pk, data_path, signature_path, quiet, output, allow_legacy)
-    } else {
-        println!("{help_usage}\n");
-        std::process::exit(1);
+fn get_sk_path(explicit_path: Option<&PathBuf>) -> Result<PathBuf> {
+    match explicit_path {
+        Some(explicit_path) => Ok(explicit_path.clone()),
+        None => match std::env::var(SIG_DEFAULT_CONFIG_DIR_ENV_VAR) {
+            Ok(env_path) => {
+                let mut complete_path = PathBuf::from(env_path);
+                complete_path.push(SIG_DEFAULT_SKFILE);
+                Ok(complete_path)
+            }
+            Err(_) => {
+                let home_path =
+                    home_dir().ok_or_else(|| PError::new(ErrorKind::Io, "can't find home dir"))?;
+                let mut complete_path = home_path;
+                complete_path.push(SIG_DEFAULT_CONFIG_DIR);
+                complete_path.push(SIG_DEFAULT_SKFILE);
+                Ok(complete_path)
+            }
+        },
     }
+}
+
+fn run(args: clap::ArgMatches, help_usage: &clap::builder::StyledStr) -> Result<()> {
+    match args.subcommand() {
+        Some(("generate", action)) => run_generate(action),
+        Some(("sign", action)) => run_sign(action),
+        Some(("verify", action)) => run_verify(action),
+        _ => {
+            println!("{help_usage}\n");
+            std::process::exit(1);
+        }
+    }
+}
+
+fn run_generate(matches: &clap::ArgMatches) -> Result<()> {
+    let force = matches.get_flag("force");
+    let sk_path = get_sk_path(matches.get_one::<PathBuf>("sk_path"))?;
+    let pk_path = get_pk_path(matches.get_one::<PathBuf>("pk_path"))?;
+    let comment = matches.get_one::<String>("comment").map(|s| s.as_str());
+    let KeyPair { pk, .. } = cmd_generate(force, &pk_path, &sk_path, comment)?;
+    println!(
+        "\nThe secret key was saved as {} - Keep it secret!",
+        sk_path.display()
+    );
+    println!(
+        "The public key was saved as {} - That one can be public.\n",
+        pk_path.display()
+    );
+    println!("Files signed using this key pair can be verified with the following command:\n");
+    println!("rsign verify <file> -P {}", pk.to_base64());
+    Ok(())
+}
+
+fn run_sign(matches: &clap::ArgMatches) -> Result<()> {
+    let sk_path = get_sk_path(matches.get_one::<PathBuf>("sk_path"))?;
+    let pk = if let Some(pk_inline) = matches.get_one::<String>("public_key") {
+        Some(PublicKey::from_base64(pk_inline)?)
+    } else if let Some(pk_path) = matches.get_one::<PathBuf>("pk_path") {
+        Some(PublicKey::from_file(get_pk_path(Some(pk_path))?)?)
+    } else {
+        None
+    };
+    let data_path = matches
+        .get_one::<PathBuf>("data")
+        .expect("'file' is required");
+    let signature_path = if let Some(file) = matches.get_one::<PathBuf>("sig_file") {
+        file.clone()
+    } else {
+        let mut sig_path = data_path.clone().into_os_string();
+        sig_path.push(SIG_SUFFIX);
+        sig_path.into()
+    };
+    let trusted_comment = matches
+        .get_one::<String>("trusted-comment")
+        .map(|s| s.as_str());
+    let untrusted_comment = matches
+        .get_one::<String>("untrusted-comment")
+        .map(|s| s.as_str());
+    cmd_sign(
+        pk,
+        sk_path,
+        signature_path,
+        data_path,
+        trusted_comment,
+        untrusted_comment,
+    )
+}
+
+fn run_verify(matches: &clap::ArgMatches) -> Result<()> {
+    let pk = if let Some(pk_inline) = matches.get_one::<String>("public_key") {
+        PublicKey::from_base64(pk_inline)?
+    } else {
+        PublicKey::from_file(get_pk_path(matches.get_one::<PathBuf>("pk_path"))?)?
+    };
+    let data_path = matches
+        .get_one::<PathBuf>("file")
+        .expect("'file' is required");
+    let signature_path = if let Some(path) = matches.get_one::<PathBuf>("sig_file") {
+        path.clone()
+    } else {
+        let mut sig_path = data_path.clone().into_os_string();
+        sig_path.push(SIG_SUFFIX);
+        sig_path.into()
+    };
+    let quiet = matches.get_flag("quiet");
+    let output = matches.get_flag("output");
+    let allow_legacy = matches.get_flag("allow-legacy");
+    cmd_verify(pk, data_path, signature_path, quiet, output, allow_legacy)
 }
 
 fn main() {

--- a/src/bin/rsign/parse_args.rs
+++ b/src/bin/rsign/parse_args.rs
@@ -1,165 +1,175 @@
-use clap::{App, Arg};
+use clap::{builder::StyledStr, command, value_parser, Arg, ArgAction, Command};
+use std::path::PathBuf;
 
-pub fn parse_args() -> (clap::ArgMatches, String) {
-    let mut app = app_from_crate!()
+pub fn parse_args() -> (clap::ArgMatches, StyledStr) {
+    let mut app = command!()
         .subcommand(
-            App::new("generate")
+            Command::new("generate")
                 .about("Generate public and private keys")
                 .arg(
                     Arg::new("pk_path")
                         .short('p')
                         .long("public-key-path")
-                        .takes_value(true)
                         .value_name("PUBLIC_KEY_PATH")
+                        .value_parser(value_parser!(PathBuf))
+                        .action(ArgAction::Set)
                         .help("path to the new public key"),
                 )
                 .arg(
                     Arg::new("sk_path")
                         .short('s')
                         .long("secret-key-path")
-                        .takes_value(true)
                         .value_name("SECRET_KEY_PATH")
+                        .value_parser(value_parser!(PathBuf))
+                        .action(ArgAction::Set)
                         .help("path to the new secret key"),
                 )
                 .arg(
                     Arg::new("force")
                         .short('f')
                         .long("force")
+                        .action(ArgAction::SetTrue)
                         .help("force generate a new keypair"),
                 )
                 .arg(
                     Arg::new("comment")
-                        .takes_value(true)
-                        .help("add a one-line untrusted comment")
-                        .value_name("COMMENT")
                         .short('c')
-                        .long("comment"),
+                        .long("comment")
+                        .value_name("COMMENT")
+                        .action(ArgAction::Set)
+                        .help("add a one-line untrusted comment"),
                 ),
         )
         .subcommand(
-            App::new("verify")
+            Command::new("verify")
                 .about("Verify a signed file with a given public key")
                 .arg(
                     Arg::new("public_key")
                         .short('P')
                         .long("public-key-string")
-                        .takes_value(true)
                         .conflicts_with("pk_path")
-                        .help("public key string")
-                        .value_name("PUBLIC_KEY_STRING"),
+                        .value_name("PUBLIC_KEY_STRING")
+                        .action(ArgAction::Set)
+                        .help("public key string"),
                 )
                 .arg(
                     Arg::new("pk_path")
                         .short('p')
                         .long("public-key-path")
-                        .takes_value(true)
                         .value_name("PUBLIC_KEY_PATH")
+                        .value_parser(value_parser!(PathBuf))
+                        .action(ArgAction::Set)
                         .help("path to public key file"),
                 )
                 .arg(
                     Arg::new("sig_file")
-                        .takes_value(true)
-                        .help("signature file to be verified")
-                        .value_name("SIG_FILE")
                         .short('x')
-                        .long("sig-file"),
+                        .long("sig-file")
+                        .value_name("SIG_FILE")
+                        .value_parser(value_parser!(PathBuf))
+                        .action(ArgAction::Set)
+                        .help("signature file to be verified"),
                 )
                 .arg(
                     Arg::new("quiet")
-                        .help("quiet mode, supress output")
-                        .takes_value(false)
                         .short('q')
-                        .long("quiet"),
+                        .long("quiet")
+                        .action(ArgAction::SetTrue)
+                        .help("quiet mode, supress output"),
                 )
                 .arg(
                     Arg::new("allow-legacy")
                         .short('l')
                         .long("allow-legacy")
+                        .action(ArgAction::SetTrue)
                         .help("accept legacy signatures"),
                 )
                 .arg(
                     Arg::new("output")
-                        .help("output the file content after verification")
-                        .takes_value(false)
                         .short('o')
-                        .long("output"),
+                        .long("output")
+                        .action(ArgAction::SetTrue)
+                        .help("output the file content after verification"),
                 )
                 .arg(
                     Arg::new("file")
                         .index(1)
-                        .takes_value(true)
                         .required(true)
-                        .help("file to be verified")
                         .value_name("FILE")
-                        .short('m')
-                        .long("file-name"),
+                        .value_parser(value_parser!(PathBuf))
+                        .action(ArgAction::Set)
+                        .help("file to be verified"),
                 ),
         )
         .subcommand(
-            App::new("sign")
+            Command::new("sign")
                 .about("Sign a file with a given private key")
                 .arg(
                     Arg::new("public_key")
                         .short('P')
                         .long("public-key-string")
-                        .takes_value(true)
                         .conflicts_with("pk_path")
-                        .help("public key string")
-                        .value_name("PUBLIC_KEY_STRING"),
+                        .value_name("PUBLIC_KEY_STRING")
+                        .action(ArgAction::Set)
+                        .help("public key string"),
                 )
                 .arg(
                     Arg::new("pk_path")
                         .short('p')
                         .long("public-key-file")
-                        .takes_value(true)
                         .value_name("PUBLIC_KEY_FILE")
+                        .value_parser(value_parser!(PathBuf))
+                        .action(ArgAction::Set)
                         .help("path to public key file"),
                 )
                 .arg(
                     Arg::new("sk_path")
                         .short('s')
                         .long("secret-key-file")
-                        .takes_value(true)
                         .value_name("SECRET_KEY_FILE")
+                        .value_parser(value_parser!(PathBuf))
+                        .action(ArgAction::Set)
                         .help("secret key to be used to sign"),
                 )
                 .arg(
                     Arg::new("sig_file")
-                        .takes_value(true)
-                        .help("signature file")
-                        .value_name("SIG_FILE")
                         .short('x')
-                        .long("sig-file"),
+                        .long("sig-file")
+                        .value_name("SIG_FILE")
+                        .value_parser(value_parser!(PathBuf))
+                        .action(ArgAction::Set)
+                        .help("signature file"),
                 )
                 .arg(
                     Arg::new("data")
                         .index(1)
-                        .takes_value(true)
                         .required(true)
-                        .help("file to sign")
                         .value_name("FILE")
-                        .short('m')
-                        .long("message-file"),
+                        .value_parser(value_parser!(PathBuf))
+                        .action(ArgAction::Set)
+                        .help("file to sign"),
                 )
                 .arg(
                     Arg::new("trusted-comment")
-                        .help("add a one-line trusted comment")
-                        .value_name("TRUSTED_COMMENT")
                         .short('t')
-                        .long("trusted-comment"),
+                        .long("trusted-comment")
+                        .value_name("TRUSTED_COMMENT")
+                        .action(ArgAction::Set)
+                        .help("add a one-line trusted comment"),
                 )
                 .arg(
                     Arg::new("untrusted-comment")
-                        .help("add a one-line untrusted comment")
-                        .value_name("UNTRUSTED_COMMENT")
                         .short('c')
-                        .long("untrusted-comment"),
+                        .long("untrusted-comment")
+                        .value_name("UNTRUSTED_COMMENT")
+                        .action(ArgAction::Set)
+                        .help("add a one-line untrusted comment"),
                 )
                 .arg(
                     Arg::new("hash")
-                        .required(false)
                         .short('H')
                         .long("hash")
+                        .action(ArgAction::SetTrue)
                         .help("ignored (for backwards compatibility only"),
                 ),
         );


### PR DESCRIPTION
- updated clap dependency from 3 -> 4.1.1
- format parser consistently
- refactor main entry point
  - split subcommands into functions
  - use claps value parsers instead of self handling conversions
- consistent search path for private and public keys "explicit > env var > ~/.rsign"